### PR TITLE
Use Pulumi state names for field delegation

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -80,7 +80,9 @@ func applyResourceIDs(info tfbridge.PropertyVisitInfo) (tfbridge.PropertyVisitRe
 
 	field := path[0].(walk.GetAttrStep).Name
 	setField := func() (tfbridge.PropertyVisitResult, error) {
-		res.Info.ComputeID = delegateIDField(resource.PropertyKey(field))
+		res.Info.ComputeID = delegateIDField(resource.PropertyKey(
+			tfbridge.TerraformToPulumiNameV2(field,
+				info.EnclosingSchemaMap(), info.EnclosingSchemaInfoMap())))
 		return tfbridge.PropertyVisitResult{HasEffect: true}, nil
 	}
 
@@ -159,12 +161,12 @@ func Provider() tfbridge.ProviderInfo {
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"meraki_administered_licensing_subscription_subscriptions_claim": {
 				ComputeID: delegateIDProperty(resource.PropertyPath{
-					"item", "subscription_id",
+					"item", "subscriptionId",
 				}),
 			},
 			"meraki_administered_licensing_subscription_subscriptions_claim_key_validate": {
 				ComputeID: delegateIDProperty(resource.PropertyPath{
-					"item", "subscription_id",
+					"item", "subscriptionId",
 				}),
 			},
 


### PR DESCRIPTION
`ComputeID` works in Pulumi's namespace, while the schema works in TF's namespace. This PR correctly gives `ComputeID` names in Pulumi's namespace.

Fixes #14 

---

Testing locally, this gets farther on the example given in #14. The example still fails, but it now fails with a new error:

<details>

<summary>New error</summary>

```
Do you want to perform this update? yes
Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/pulumi/ts/dev/updates/285

Loading policy packs...

     Type                              Name    Status                       Info
 +   pulumi:pulumi:Stack               ts-dev  **creating failed (6s)**     1 error; 76 messages
 +   ├─ meraki:networks:base           net     created (1s)                 
 +   └─ meraki:networks:WirelessSsids  ssids   **creating failed**          1 error

Policies:
    ✅ pulumi-internal-policies@v0.0.6

Diagnostics:
  pulumi:pulumi:Stack (ts-dev):
    2024/05/17 12:24:56 [DEBUG] Selecting method. Method 1 [false false false]
    2024/05/17 12:24:56 [DEBUG] Selecting method. Method 2 [false]
    2024/05/17 12:24:56 [DEBUG] Selected method: GetOrganizations

    2024/05/17 12:24:59 State: NetworkID value is "L_686235993220609563", OrganizationID value is "1541814", EnrollmentString value is <unknown>, ID value is <unknown>, IsBoundToConfigTemplate value is <unknown>, Name value is "pulumi-testing", Notes value is "Created by Pulumi", ProductTypes value is ["appliance","switch","wireless"], Tags value is <unknown>, TimeZone value is "America/Los_Angeles", URL value is <unknown>
    2024/05/17 12:24:59 Resp: NetworkID value is <null>, OrganizationID value is "1541814", EnrollmentString value is "", ID value is "L_686235993220609563", IsBoundToConfigTemplate value is false, Name value is "pulumi-testing", Notes value is "Created by Pulumi", ProductTypes value is ["appliance","switch","wireless"], Tags value is <null>, TimeZone value is "America/Los_Angeles", URL value is "https://n219.meraki.com/pulumi-testing-s/n/PoLBwcBd/manage/usage/list"
    2024/05/17 12:24:59 IF unkown:
    2024/05/17 12:24:59 IF unkown:
    2024/05/17 12:24:59 IF unkown:
    2024/05/17 12:24:59 IF unkown:
    2024/05/17 12:24:59 IF unkown:
    2024/05/17 12:24:59 [DEBUG] result: NetworkID value is "L_686235993220609563", OrganizationID value is "1541814", EnrollmentString value is "", ID value is "L_686235993220609563", IsBoundToConfigTemplate value is false, Name value is "pulumi-testing", Notes value is "Created by Pulumi", ProductTypes value is ["appliance","switch","wireless"], Tags value is <null>, TimeZone value is "America/Los_Angeles", URL value is "https://n219.meraki.com/pulumi-testing-s/n/PoLBwcBd/manage/usage/list"
    2024/05/17 12:24:59 EncryptionMode: wpa
    2024/05/17 12:24:59 Condition: false
    2024/05/17 12:25:00 State: NetworkID value is "L_686235993220609563", Number value is 0, AdminSplashURL value is <unknown>, AuthMode value is "psk", AvailabilityTags value is <unknown>, AvailableOnAllAps value is <unknown>, BandSelection value is <unknown>, Enabled value is true, EncryptionMode value is "wpa", IPAssignmentMode value is <unknown>, LocalAuth value is <unknown>, MandatoryDhcpEnabled value is <unknown>, MinBitrate value is <unknown>, Name value is "pulumi-test-234", PerClientBandwidthLimitDown value is <unknown>, PerClientBandwidthLimitUp value is <unknown>, PerSSIDBandwidthLimitDown value is <unknown>, PerSSIDBandwidthLimitUp value is <unknown>, RadiusAccountingEnabled value is <unknown>, RadiusAccountingServers value is <nil>, RadiusAttributeForGroupPolicies value is <unknown>, RadiusEnabled value is <unknown>, RadiusFailoverPolicy value is <unknown>, RadiusLoadBalancingPolicy value is <unknown>, RadiusServers value is <nil>, RadiusServersResponse value is <nil>, SplashPage value is <unknown>, SplashTimeout value is <unknown>, SSIDAdminAccessible value is <unknown>, Visible value is <unknown>, WalledGardenEnabled value is <unknown>, WalledGardenRanges value is <unknown>, WpaEncryptionMode value is <unknown>, ActiveDirectory value is <nil>, AdultContentFilteringEnabled value is <unknown>, ApTagsAndVLANIDs value is <nil>, ConcentratorNetworkID value is <unknown>, DefaultVLANID value is <unknown>, DisassociateClientsOnVpnFailover value is <unknown>, DNSRewrite value is <nil>, Dot11R value is <nil>, Dot11W value is <nil>, EnterpriseAdminAccess value is <unknown>, Gre value is <nil>, LanIsolationEnabled value is <unknown>, Ldap value is <nil>, LocalRadius value is <nil>, NamedVLANs value is <nil>, Oauth value is <nil>, Psk value is "testfromhi", RadiusAccountingInterimInterval value is <unknown>, RadiusAuthenticationNasID value is <unknown>, RadiusCalledStationID value is <unknown>, RadiusCoaEnabled value is <unknown>, RadiusFallbackEnabled value is <unknown>, RadiusGuestVLANEnabled value is <unknown>, RadiusGuestVLANID value is <unknown>, RadiusOverride value is <unknown>, RadiusProxyEnabled value is <unknown>, RadiusServerAttemptsLimit value is <unknown>, RadiusServerTimeout value is <unknown>, RadiusTestingEnabled value is <unknown>, SecondaryConcentratorNetworkID value is <unknown>, SpeedBurst value is <nil>, SplashGuestSponsorDomains value is <null>, UseVLANTagging value is <unknown>, VLANID value is <unknown>
    2024/05/17 12:25:00 Resp: NetworkID value is <null>, Number value is 0, AdminSplashURL value is "", AuthMode value is "psk", AvailabilityTags value is <null>, AvailableOnAllAps value is true, BandSelection value is "Dual band operation", Enabled value is true, EncryptionMode value is "wpa", IPAssignmentMode value is "NAT mode", LocalAuth value is <null>, MandatoryDhcpEnabled value is false, MinBitrate value is 11, Name value is "pulumi-test-234", PerClientBandwidthLimitDown value is 0, PerClientBandwidthLimitUp value is 0, PerSSIDBandwidthLimitDown value is 0, PerSSIDBandwidthLimitUp value is 0, RadiusAccountingEnabled value is <null>, RadiusAccountingServers value is &[], RadiusAttributeForGroupPolicies value is "", RadiusEnabled value is <null>, RadiusFailoverPolicy value is "", RadiusLoadBalancingPolicy value is "", RadiusServers value is <nil>, RadiusServersResponse value is &[], SplashPage value is "None", SplashTimeout value is "", SSIDAdminAccessible value is false, Visible value is true, WalledGardenEnabled value is <null>, WalledGardenRanges value is <null>, WpaEncryptionMode value is "WPA2 only", ActiveDirectory value is <nil>, AdultContentFilteringEnabled value is <null>, ApTagsAndVLANIDs value is <nil>, ConcentratorNetworkID value is <null>, DefaultVLANID value is <unknown>, DisassociateClientsOnVpnFailover value is <null>, DNSRewrite value is <nil>, Dot11R value is <nil>, Dot11W value is <nil>, EnterpriseAdminAccess value is <null>, Gre value is <nil>, LanIsolationEnabled value is <null>, Ldap value is <nil>, LocalRadius value is <nil>, NamedVLANs value is <nil>, Oauth value is <nil>, Psk value is "testfromhi", RadiusAccountingInterimInterval value is <null>, RadiusAuthenticationNasID value is <null>, RadiusCalledStationID value is <null>, RadiusCoaEnabled value is <null>, RadiusFallbackEnabled value is <null>, RadiusGuestVLANEnabled value is <null>, RadiusGuestVLANID value is <null>, RadiusOverride value is <null>, RadiusProxyEnabled value is <null>, RadiusServerAttemptsLimit value is <null>, RadiusServerTimeout value is <null>, RadiusTestingEnabled value is <null>, SecondaryConcentratorNetworkID value is <null>, SpeedBurst value is <nil>, SplashGuestSponsorDomains value is <null>, UseVLANTagging value is <null>, VLANID value is <null>
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF DeepEqual:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF DeepEqual:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 IF unkown:
    2024/05/17 12:25:00 [DEBUG] result: NetworkID value is "L_686235993220609563", Number value is 0, AdminSplashURL value is "", AuthMode value is "psk", AvailabilityTags value is <null>, AvailableOnAllAps value is true, BandSelection value is "Dual band operation", Enabled value is true, EncryptionMode value is "wpa", IPAssignmentMode value is "NAT mode", LocalAuth value is <null>, MandatoryDhcpEnabled value is false, MinBitrate value is 11, Name value is "pulumi-test-234", PerClientBandwidthLimitDown value is 0, PerClientBandwidthLimitUp value is 0, PerSSIDBandwidthLimitDown value is 0, PerSSIDBandwidthLimitUp value is 0, RadiusAccountingEnabled value is <null>, RadiusAccountingServers value is &[], RadiusAttributeForGroupPolicies value is "", RadiusEnabled value is <null>, RadiusFailoverPolicy value is "", RadiusLoadBalancingPolicy value is "", RadiusServers value is <nil>, RadiusServersResponse value is &[], SplashPage value is "None", SplashTimeout value is "", SSIDAdminAccessible value is false, Visible value is true, WalledGardenEnabled value is <null>, WalledGardenRanges value is <null>, WpaEncryptionMode value is "WPA2 only", ActiveDirectory value is <nil>, AdultContentFilteringEnabled value is <null>, ApTagsAndVLANIDs value is <nil>, ConcentratorNetworkID value is <null>, DefaultVLANID value is <unknown>, DisassociateClientsOnVpnFailover value is <null>, DNSRewrite value is <nil>, Dot11R value is <nil>, Dot11W value is <nil>, EnterpriseAdminAccess value is <null>, Gre value is <nil>, LanIsolationEnabled value is <null>, Ldap value is <nil>, LocalRadius value is <nil>, NamedVLANs value is <nil>, Oauth value is <nil>, Psk value is "testfromhi", RadiusAccountingInterimInterval value is <null>, RadiusAuthenticationNasID value is <null>, RadiusCalledStationID value is <null>, RadiusCoaEnabled value is <null>, RadiusFallbackEnabled value is <null>, RadiusGuestVLANEnabled value is <null>, RadiusGuestVLANID value is <null>, RadiusOverride value is <null>, RadiusProxyEnabled value is <null>, RadiusServerAttemptsLimit value is <null>, RadiusServerTimeout value is <null>, RadiusTestingEnabled value is <null>, SecondaryConcentratorNetworkID value is <null>, SpeedBurst value is <nil>, SplashGuestSponsorDomains value is <null>, UseVLANTagging value is <null>, VLANID value is <null>

    error: update failed

  meraki:networks:WirelessSsids (ssids):
    error: unexpected unknown property value for "defaultVlanId"

```

</details>