### PR TITLE
Add Cisco to Meraki in visible strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Meraki Resource Provider
+# Cisco Meraki Resource Provider
 
-The Meraki Resource Provider lets you manage [meraki](https://www.pulumi.com/registry/packages/meraki/) resources.
+The Cisco Meraki Resource Provider lets you manage [meraki](https://www.pulumi.com/registry/packages/meraki/) resources.
 
 ## Installing
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -6,7 +6,7 @@ layout: installation
 
 ## Installation
 
-The Pulumi Meraki provider is available as a package in all Pulumi languages:
+The Pulumi Cisco Meraki provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@pulumi/meraki`](https://www.npmjs.com/package/@pulumi/meraki)
 * Python: [`pulumi_meraki`](https://pypi.org/project/pulumi_meraki/)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -127,7 +127,7 @@ func Provider() tfbridge.ProviderInfo {
 		Name: "meraki",
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
-		DisplayName: "Meraki",
+		DisplayName: "Cisco Meraki",
 		// The default publisher for all packages is Pulumi.
 		// Change this to your personal name (or a company name) that you
 		// would like to be shown in the Pulumi Registry if this package is published
@@ -140,7 +140,7 @@ func Provider() tfbridge.ProviderInfo {
 		// for use in Pulumi programs
 		// e.g https://github.com/org/pulumi-provider-name/releases/
 		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-meraki",
-		Description:       "A Pulumi package for creating and managing Meraki resources",
+		Description:       "A Pulumi package for creating and managing Cisco Meraki resources",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in
 		// https://www.pulumi.com/docs/guides/pulumi-packages/schema/#package.

--- a/sdk/dotnet/Administered/README.md
+++ b/sdk/dotnet/Administered/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/dotnet/Config/README.md
+++ b/sdk/dotnet/Config/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/dotnet/Devices/README.md
+++ b/sdk/dotnet/Devices/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/dotnet/Networks/README.md
+++ b/sdk/dotnet/Networks/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/dotnet/Organizations/README.md
+++ b/sdk/dotnet/Organizations/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/dotnet/Pulumi.Meraki.csproj
+++ b/sdk/dotnet/Pulumi.Meraki.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>pulumi</Authors>
     <Company>pulumi</Company>
-    <Description>A Pulumi package for creating and managing Meraki resources</Description>
+    <Description>A Pulumi package for creating and managing Cisco Meraki resources</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/pulumi/pulumi-meraki</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-meraki</RepositoryUrl>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/go/meraki/doc.go
+++ b/sdk/go/meraki/doc.go
@@ -1,2 +1,2 @@
-// A Pulumi package for creating and managing Meraki resources
+// A Pulumi package for creating and managing Cisco Meraki resources
 package meraki

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Meraki resources
+A Pulumi package for creating and managing Cisco Meraki resources

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -92,7 +92,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "A Pulumi package for creating and managing Meraki resources"
+                description = "A Pulumi package for creating and managing Cisco Meraki resources"
 
                 url = "https://github.com/pulumi/pulumi-meraki"
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pulumi/meraki",
     "version": "0.0.0-alpha.0+dev",
-    "description": "A Pulumi package for creating and managing Meraki resources. Based on terraform-provider-meraki: version v0.2.0",
+    "description": "A Pulumi package for creating and managing Cisco Meraki resources. Based on terraform-provider-meraki: version v0.2.0",
     "keywords": [
         "pulumi",
         "meraki",

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
-# Meraki Resource Provider
+# Cisco Meraki Resource Provider
 
-The Meraki Resource Provider lets you manage [meraki](https://www.pulumi.com/registry/packages/meraki/) resources.
+The Cisco Meraki Resource Provider lets you manage [meraki](https://www.pulumi.com/registry/packages/meraki/) resources.
 
 ## Installing
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_meraki"
-  description = "A Pulumi package for creating and managing Meraki resources"
+  description = "A Pulumi package for creating and managing Cisco Meraki resources"
   dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   keywords = ["pulumi", "meraki", "category/network"]
   readme = "README.md"


### PR DESCRIPTION
Add "Cisco" in front of "Meraki" in all user-visible strings

Fix https://github.com/pulumi/registry/issues/4580 in the next provider release