### PR TITLE
Remove publisher and adjust homepage to fix Java publishing

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -128,11 +128,6 @@ func Provider() tfbridge.ProviderInfo {
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
 		DisplayName: "Cisco Meraki",
-		// The default publisher for all packages is Pulumi.
-		// Change this to your personal name (or a company name) that you
-		// would like to be shown in the Pulumi Registry if this package is published
-		// there.
-		Publisher: "pulumi",
 		// LogoURL points to the assets/meraki.png file on the assets branch of
 		// this repo.
 		LogoURL: "https://raw.githubusercontent.com/pulumi/pulumi-meraki/assets/assets/meraki.png",
@@ -150,7 +145,7 @@ func Provider() tfbridge.ProviderInfo {
 			"category/network",
 		},
 		License:    "Apache-2.0",
-		Homepage:   "https://github.com/pulumi/pulumi-meraki",
+		Homepage:   "https://pulumi.com",
 		Repository: "https://github.com/pulumi/pulumi-meraki",
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.

--- a/sdk/dotnet/Pulumi.Meraki.csproj
+++ b/sdk/dotnet/Pulumi.Meraki.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>pulumi</Authors>
-    <Company>pulumi</Company>
+    <Authors>Pulumi Corp.</Authors>
+    <Company>Pulumi Corp.</Company>
     <Description>A Pulumi package for creating and managing Cisco Meraki resources</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pulumi/pulumi-meraki</PackageProjectUrl>
+    <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-meraki</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
     <Version>0.0.0-alpha.0+dev</Version>

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -89,8 +89,8 @@ publishing {
             artifact javadocJar
 
             pom {
-                inceptionYear = ""
-                name = ""
+                inceptionYear = "2022"
+                name = "pulumi-meraki"
                 packaging = "jar"
                 description = "A Pulumi package for creating and managing Cisco Meraki resources"
 
@@ -111,9 +111,9 @@ publishing {
 
                 developers {
                     developer {
-                        id = ""
-                        name = ""
-                        email = ""
+                        id = "pulumi"
+                        name = "Pulumi"
+                        email = "support@pulumi.com"
                     }
                 }
             }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -7,7 +7,7 @@
         "meraki",
         "category/network"
     ],
-    "homepage": "https://github.com/pulumi/pulumi-meraki",
+    "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-meraki",
     "license": "Apache-2.0",
     "scripts": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -9,7 +9,7 @@
   [project.license]
     text = "Apache-2.0"
   [project.urls]
-    Homepage = "https://github.com/pulumi/pulumi-meraki"
+    Homepage = "https://pulumi.com"
     Repository = "https://github.com/pulumi/pulumi-meraki"
 
 [build-system]


### PR DESCRIPTION
Same as https://github.com/pulumi/pulumi-dbtcloud/pull/23

Right now, the Java publishing step fails because POM values aren't set correctly. We need to set the publisher and/or home page to expected values. This PR removes the non-canonical publisher (could have been Pulumi) and set the canonical homepage.