### PR TITLE
Patch vlan profiles to fix wrong diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ sdk/java/gradlew.bat
 sdk/python/venv
 
 sdk/dotnet/logo.png
+
+go.work
+go.work.sum

--- a/patches/0001-Add-shim.patch
+++ b/patches/0001-Add-shim.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add shim
 
 diff --git a/meraki/shim.go b/meraki/shim.go
 new file mode 100644
-index 0000000..895da58
+index 0000000..1104b47
 --- /dev/null
 +++ b/meraki/shim.go
 @@ -0,0 +1,12 @@

--- a/patches/0002-patch-vlan-profiles-to-be-non-computed.patch
+++ b/patches/0002-patch-vlan-profiles-to-be-non-computed.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Fri, 12 Jul 2024 17:27:42 +0100
+Subject: [PATCH] patch vlan profiles to be non-computed
+
+
+diff --git a/internal/provider/resource_meraki_networks_vlan_profiles.go b/internal/provider/resource_meraki_networks_vlan_profiles.go
+index 80dbca9..3cb4b2e 100644
+--- a/internal/provider/resource_meraki_networks_vlan_profiles.go
++++ b/internal/provider/resource_meraki_networks_vlan_profiles.go
+@@ -152,7 +152,6 @@ func (r *NetworksVLANProfilesResource) Schema(_ context.Context, _ resource.Sche
+ 						},
+ 						"name": schema.StringAttribute{
+ 							MarkdownDescription: `Name of the VLAN, string length must be from 1 to 32 characters`,
+-							Computed:            true,
+ 							Optional:            true,
+ 							PlanModifiers: []planmodifier.String{
+ 								stringplanmodifier.UseStateForUnknown(),

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -18831,7 +18831,7 @@ export namespace networks {
         /**
          * Name of the VLAN, string length must be from 1 to 32 characters
          */
-        name: string;
+        name?: string;
         /**
          * VLAN ID
          */


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-meraki/issues/97 with a patch while we resolve the underlying bridge issue.

I've set the `name` property on the `vlan_names` to be non-computed - this works around the bridge issue.

I believe this patch is perfectly safe to take - name is not really computed - the resource does not actually work if not specified.
