### PR TITLE
Do not run upgrade check for this provider

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -28,3 +28,4 @@ actions:
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 registryDocs: true
+checkUpstreamUpgrade: false


### PR DESCRIPTION
Because the upstream provider is pre-stable release, we run upgrades manually.

Fixes #200.
