### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -209,6 +209,7 @@ func Provider() tfbridge.ProviderInfo {
 		Java: &tfbridge.JavaInfo{
 			BasePackage: "com.pulumi",
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	tfbridge.MustTraverseProperties(&prov, "ids", applyResourceIDs)


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598